### PR TITLE
Unknown: preg_replace() .. null .. in ..\system\engine\action.php on …

### DIFF
--- a/upload/system/engine/action.php
+++ b/upload/system/engine/action.php
@@ -34,7 +34,7 @@ class Action {
 		}
 
 		$file = DIR_APPLICATION . 'controller/' . $this->route . '.php';		
-		$class = 'Controller' . preg_replace('/[^a-zA-Z0-9]/', '', $this->route);
+		$class = 'Controller' . preg_replace('/[^a-zA-Z0-9]/', '', (string)$this->route);
 		
 		// Initialize the class
 		if (is_file($file)) {


### PR DESCRIPTION
…line 39

Unknown: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in ..\system\engine\action.php on line 39

Happen sometimes (e.g. with custom extensions) that $this->route is null, therefore this error is shown.