### PR TITLE
define customer_id

### DIFF
--- a/upload/system/library/cart/customer.php
+++ b/upload/system/library/cart/customer.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cart;
 class Customer {
-	private $customer_id;
+	private $customer_id = 0;
 	private $firstname;
 	private $lastname;
 	private $customer_group_id;


### PR DESCRIPTION
if not defined, when no customer id is given (e.g. customer is not logged in), this error will be shown:
**Fatal error: Uncaught TypeError: ModelToolOnline::addOnline(): Argument #2 ($customer_id) must be of type int, null given**