### PR TITLE
Update mail.php

### DIFF
--- a/upload/system/library/mail.php
+++ b/upload/system/library/mail.php
@@ -388,14 +388,10 @@ class Mail {
 				$lines = explode("\n", $message);
 
 				foreach ($lines as $line) {
-					$results = str_split($line, 998);
-
-					foreach ($results as $result) {
-						if (substr(PHP_OS, 0, 3) != 'WIN') {
-							fputs($handle, $result . "\r\n");
-						} else {
-							fputs($handle, str_replace("\n", "\r\n", $result) . "\r\n");
-						}
+					$results = ($line === '') ? [''] : str_split($line, 998);
+					
+					foreach($results as $result) {
+						fputs($handle, $result . "\r\n");
 					}
 				}
 


### PR DESCRIPTION
Changed how str_split is handled in php 8.2.x https://php.watch/versions/8.2/str_split-empty-string-empty-array otherwise message is not sended. 
See also https://github.com/opencart/opencart/blob/a37712685ac8f52c97533bedea077ecdd086b7e6/upload/system/library/mail/smtp.php#L236